### PR TITLE
Update nnnn-structured-concurrency.md

### DIFF
--- a/proposals/nnnn-structured-concurrency.md
+++ b/proposals/nnnn-structured-concurrency.md
@@ -313,6 +313,7 @@ To futher analyze the semantics of deadlines, let's extend our dinner preparatio
 ```swift
 func makeDinnerWithDeadline() async throws -> Meal {
   await try Task.withDeadline(in: .hours(2)) {
+    // intentionally wait until the vegetables have been chopped before starting any child tasks
     let veggies = await try chopVegetables()
     async let meat = Task.withDeadline(in: .minutes(30)) {
       marinateMeat()


### PR DESCRIPTION
At first, I was wondering why it wasn't `async let veggies`, like the previous examples. After reading the paragraph below the code example, I realized the `let veggies` was intentional. Maybe this comment will help avoid confusion for the next reader?