### PR TITLE
Add function declarations to 2nd makeDinner code

### DIFF
--- a/proposals/nnnn-structured-concurrency.md
+++ b/proposals/nnnn-structured-concurrency.md
@@ -153,6 +153,12 @@ Our approach follows the principles of *structured concurrency* described above.
 This proposal introduces an easy way to create child tasks with `async let`:
 
 ```swift
+func chopVegetables() async throws -> [Vegetable] { ... }
+func marinateMeat() async -> Meat { ... }
+func preheatOven(temperature: Double) async throws -> Oven { ... }
+
+// ...
+
 func makeDinner() async throws -> Meal {
   async let veggies = chopVegetables()
   async let meat = marinateMeat()


### PR DESCRIPTION
The paragraph on line 181 starts with the following sentence. 

> Bringing it back to our example, note that the `chopVegetables()` function might throw an error if, say, there is an incident with the kitchen knife.

Since it's been over 100 lines non-wrapped text since the reader last saw this function declaration (and its `throws` keyword), it may be helpful to also include the all three function declarations here again. I know I had to scroll back up to re-read the very first code example to refresh my memory.