### PR TITLE
Add missing return keyword

### DIFF
--- a/proposals/nnnn-structured-concurrency.md
+++ b/proposals/nnnn-structured-concurrency.md
@@ -199,7 +199,7 @@ Introducing `async let` into the loop would not produce any meaningful concurren
 /// Concurrently chop the vegetables.
 func chopVegetables() async throws -> [Vegetable] {
   // Create a task group where each task produces (Int, Vegetable).
-  try await Task.withGroup(resultType: (Int, Vegetable).self) { group in 
+  return try await Task.withGroup(resultType: (Int, Vegetable).self) { group in 
     var veggies: [Vegetable] = gatherRawVeggies()
     
     // Create a new child task for each vegetable that needs to be 


### PR DESCRIPTION
Is there a missing `return` keyword in this code example? I was surprised not to see one. Can the `return` be omitted in Swift 5.1 because of [SE-0255: Implicit Returns from Single-Expression Functions](https://github.com/apple/swift-evolution/blob/master/proposals/0255-omit-return.md)?