### PR TITLE
Fix makeDinnerTaskGroup code example

### DIFF
--- a/proposals/nnnn-structured-concurrency.md
+++ b/proposals/nnnn-structured-concurrency.md
@@ -243,7 +243,7 @@ We can then re-implement `makeDinner` with only a task group:
 
 ```swift
 func makeDinnerTaskGroup() async throws -> Meal {
-  withTaskGroup(resultType: DinnerChildTask.self) { group in    
+  return try await Task.withGroup(resultType: DinnerChildTask.self) { group in    
     await group.add {
       DinnerChild.chopVegetables(await chopVegetables())
     }
@@ -260,6 +260,7 @@ func makeDinnerTaskGroup() async throws -> Meal {
     var meat: Meat? = nil
     var oven: Oven? = nil
     var dish: Dish? = nil
+    
     while let child = try await group.next() {
       switch child {
         case .chopVegetables(let newVeggies):

--- a/proposals/nnnn-structured-concurrency.md
+++ b/proposals/nnnn-structured-concurrency.md
@@ -243,7 +243,7 @@ We can then re-implement `makeDinner` with only a task group:
 
 ```swift
 func makeDinnerTaskGroup() async throws -> Meal {
-  return try await Task.withGroup(resultType: DinnerChildTask.self) { group in    
+  return try await Task.withGroup(resultType: DinnerChild.self) { group in    
     await group.add {
       DinnerChild.chopVegetables(await chopVegetables())
     }


### PR DESCRIPTION
The `makeDinnerTaskGroup()` code example has a couple of potential issues:

1. The `withTaskGroup()` function doesn't seem to be defined or mentioned anywhere else in this proposal. Do you mean `Task.withGroup`?
1. There are no `try await` keywords prepended to the expression initializing the task group. Was this an accidental omission?
1. There is no `return` keyword prepended to the expression either. I'm not sure if this is needed or not; see my [previous pull request](https://github.com/DougGregor/swift-evolution/pull/41).
1. The result type is `DinnerChildTask.self`. Should it be `DinnerChild.self`? 
1. [Nit-pick] It is a bit easier to read with a newline between the end of the optional declarations and the start of the `while` loop.