### PR TITLE
Prepend try to throwing async function calls

### DIFF
--- a/proposals/nnnn-structured-concurrency.md
+++ b/proposals/nnnn-structured-concurrency.md
@@ -245,7 +245,7 @@ We can then re-implement `makeDinner` with only a task group:
 func makeDinnerTaskGroup() async throws -> Meal {
   withTaskGroup(resultType: DinnerChildTask.self) { group in    
     await group.add {
-      DinnerChild.chopVegetables(await chopVegetables())
+      DinnerChild.chopVegetables(try await chopVegetables())
     }
     
     await group.add {
@@ -253,7 +253,7 @@ func makeDinnerTaskGroup() async throws -> Meal {
     }
     
     await group.add {
-      DinnerChild.preheatOven(await preheatOven(temperature: 350))
+      DinnerChild.preheatOven(try await preheatOven(temperature: 350))
     }
     
     var veggies: [Vegetable]? = nil


### PR DESCRIPTION
Since both the `chopVegetables()` and `preheatOven(temperature:)` async functions can throw, does this code example need to prepend a `try` keyword before awaiting on them?