### PR TITLE
Add try await keywords when chopping veggies

### DIFF
--- a/proposals/nnnn-structured-concurrency.md
+++ b/proposals/nnnn-structured-concurrency.md
@@ -206,7 +206,7 @@ func chopVegetables() async throws -> [Vegetable] {
     // chopped.
     for i in veggies.indices {
       await group.add { 
-        (i, veggies[i].chopped())
+        (i, try await veggies[i].chopped())
       }
     }
 


### PR DESCRIPTION
Is this code example missing the `try await` keywords when chopping veggies? In the previous example, inside the loop that would not produce any meaningful concurrency, line 190 is written:

```swift
veggies[i] = try await veggies[i].chopped()
```

It seems like the `chopped()` method  has the potential for an async kitchen knife incident for each veggie. I assume this potential also needs to be accounted for in the meaningful concurrency example too?